### PR TITLE
Breaking change: added data param to del() method

### DIFF
--- a/__tests__/adapter.spec.js
+++ b/__tests__/adapter.spec.js
@@ -289,9 +289,7 @@ describe('adapter', () => {
   describe('del', () => {
     let ret
 
-    const action = () => {
-      ret = adapter.del('/users')
-    }
+    const action = () => { ret = adapter.del('/users', { foo: 'bar' }) }
 
     describe('when it resolves', () => {
       const values = { id: 1, name: 'paco' }
@@ -312,7 +310,7 @@ describe('adapter', () => {
             contentType: 'application/json',
             headers: { 'SomeHeader': 'test' },
             xhrFields: { withCredentials: true },
-            data: null
+            data: '{"foo":"bar"}'
           })
         })
       })

--- a/src/index.js
+++ b/src/index.js
@@ -132,10 +132,10 @@ export default {
     )
   },
 
-  del (path: string, options?: {} = {}): Request {
+  del (path: string, data: ?{}, options?: {} = {}): Request {
     return ajax(
       `${this.apiPath}${path}`,
-      merge({}, { method: 'DELETE' }, this.commonOptions, options)
+      merge({}, { method: 'DELETE', data }, this.commonOptions, options)
     )
   }
 }


### PR DESCRIPTION
# WAT
- Changed signature of del() method: now you can pass `data` to the request like in the other methods.
- Removed 🎩from dependencies
- Added yarn lock
- Fixed `flowconfig` that was ignoring `/react/node_modules`?